### PR TITLE
use seed when image is generated

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -103,7 +103,7 @@ def _gen_shape(
     if image is None:
         start_time = time.time()
         try:
-            image = t2i_worker(caption)
+            image = t2i_worker(caption, seed=seed)
         except Exception as e:
             raise gr.Error(f"Text to 3D is disabled. Please enable it by restarted the app with `python gradio_app.py --enable_t23d`.")
         time_meta['text2image'] = time.time() - start_time


### PR DESCRIPTION
In gradio_app.py, seed parameter is not used when image is generated.
Therefore, I added parameter to `__call__`  method for `t2i_worker` instance.
